### PR TITLE
Handle invalid token in auth middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func isAuthorizedMiddleware(next func(userID int, w http.ResponseWriter, r *http
 		token, err := jwt.Parse(authToken, func(token *jwt.Token) (interface{}, error) {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 				logger.Error("Unable to parse JWT token", "path", r.URL.Path)
-				http.Error(w, "Unauthorized0", http.StatusUnauthorized)
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return nil, nil
 			}
 			return []byte(jwtSecret), nil

--- a/main.go
+++ b/main.go
@@ -123,6 +123,10 @@ func isAuthorizedMiddleware(next func(userID int, w http.ResponseWriter, r *http
 			next(userID, w, r)
 			return
 		}
+
+		logger.Error("Invalid Token", "error", err)
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
 	})
 }
 


### PR DESCRIPTION
This should address the following user-reported bug:

```
Error: status: 401, body: token contains an invalid number of segments
```
