### PR TITLE
Add multi-arch builds to release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,30 @@
-version: 2
+version: 2.1
+
+commands:
+
+  configure-dockerhub:
+    description: Configure Docker Hub access
+    steps:
+      - run:
+          name: docker login
+          command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+
+  install-docker-buildx:
+    description: Install Docker Buildx
+    steps:
+      - run:
+          name: Install Docker Buildx
+          command: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx version
+            sudo apt-get update && sudo apt-get install -y binfmt-support qemu-user-static
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            docker run --privileged --rm tonistiigi/binfmt --install arm64
+            docker context create buildcontext
+            docker buildx create buildcontext --use
+
 jobs:
   build-go:
     docker:
@@ -16,7 +42,10 @@ jobs:
           command: go test -v ./...
       - run:
           name: build application (linux)
-          command: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/product-api
+          command: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./bin/amd64/product-api
+      - run:
+          name: build application (arm64)
+          command: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ./bin/arm64/product-api
       - persist_to_workspace:
           root: /go/src/github.com/hashicorpdemoapp
           paths:
@@ -32,7 +61,7 @@ jobs:
       - setup_remote_docker
       - attach_workspace:
           at: /go/src/github.com/hashicorpdemoapp
-      - run: 
+      - run:
           name: install shipyard
           command: |
             curl https://shipyard.run/install | bash
@@ -42,47 +71,45 @@ jobs:
 
   publish-docker-release:
     docker:
-      - image: circleci/golang:1.13
-    environment:
-      GO111MODULE: "on"
-    working_directory: /go/src/github.com/hashicorpdemoapp/product-api-go
+      - image: cimg/base:stable
+    working_directory: ~/go/src/github.com/hashicorpdemoapp/product-api-go
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.14
+      - install-docker-buildx
+      - configure-dockerhub
       - attach_workspace:
-          at: /go/src/github.com/hashicorpdemoapp
-      - run:
-          name: docker login
-          command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-      - run:
-          name: docker build
-          command: |
-            docker build -t hashicorpdemoapp/product-api:${CIRCLE_TAG} .
+          at: ~/go/src/github.com/hashicorpdemoapp
       - run:
           name: docker push
           command: |
-            docker push hashicorpdemoapp/product-api:${CIRCLE_TAG}
-  
+            docker buildx inspect --bootstrap
+            docker buildx build --platform linux/arm64,linux/amd64 \
+                -t hashicorpdemoapp/product-api:${CIRCLE_TAG} \
+                -f ./Dockerfile \
+                ./bin \
+                --push
+
   publish-docker-db-release:
     docker:
-      - image: circleci/golang:1.13
-    environment:
-      GO111MODULE: "on"
-    working_directory: /go/src/github.com/hashicorpdemoapp/product-api-go
+      - image: cimg/base:stable
+    working_directory: ~/go/src/github.com/hashicorpdemoapp/product-api-go
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.14
+      - install-docker-buildx
+      - configure-dockerhub
       - attach_workspace:
-          at: /go/src/github.com/hashicorpdemoapp
-      - run:
-          name: docker login
-          command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-      - run:
-          name: docker build
-          command: |
-            cd database && docker build -t hashicorpdemoapp/product-api-db:${CIRCLE_TAG} .
+          at: ~/go/src/github.com/hashicorpdemoapp
       - run:
           name: docker push
           command: |
-            docker push hashicorpdemoapp/product-api-db:${CIRCLE_TAG}
+            docker buildx inspect --bootstrap
+              docker buildx build --platform linux/arm64,linux/amd64 \
+                -t hashicorpdemoapp/product-api-db:${CIRCLE_TAG} \
+                -f ./database/Dockerfile \
+                ./database \
+                --push
 
   publish-github-release:
     docker:
@@ -91,6 +118,12 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/go/src/github.com/hashicorpdemoapp
+      - run:
+          name: "Zip binaries"
+          command: |
+            cd ./bin
+            zip -j product_api_go_linux_amd64.zip ./amd64/product-api
+            zip -j product_api_go_linux_arm64.zip ./arm64/product-api
       - run:
           name: "Publish Release on GitHub"
           command: |
@@ -101,7 +134,7 @@ workflows:
   build:
     jobs:
       - build-go
-      - functional_test: 
+      - functional_test:
           requires:
             - build-go
 
@@ -110,7 +143,9 @@ workflows:
       - build-go:
           filters:
             tags:
-              only: /.*/
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - publish-docker-release:
           requires:
             - build-go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,27 @@
-FROM alpine:latest
+FROM alpine:latest as base
 
 RUN addgroup api && \
   adduser -D -G api api
 
 RUN mkdir /app
 
-COPY ./bin/product-api /app/product-api
+# Copy AMD binaries
+FROM base AS image-amd64
+
+COPY amd64/product-api /app/product-api
+RUN chmod +x /app/product-api
+
+# Copy ARM binaries
+FROM base AS image-arm64
+
+COPY arm64/product-api /app/product-api
+RUN chmod +x /app/product-api
+
+FROM image-${TARGETARCH}
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
 ENTRYPOINT [ "/app/product-api" ]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CONTAINER_NAME=hashicorpdemoapp/product-api
 DB_CONTAINER_NAME=hashicorpdemoapp/product-api-db
-CONTAINER_VERSION=v0.0.12
+CONTAINER_VERSION=v0.0.16
 
 test_functional:
 	shipyard run ./blueprint
@@ -8,13 +8,31 @@ test_functional:
 	shipyard destroy
 
 build_db:
-	cd database && docker build -t ${DB_CONTAINER_NAME}:${CONTAINER_VERSION} .
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	docker buildx create --name multi-db || true
+	docker buildx use multi-db
+	docker buildx inspect --bootstrap
+	docker buildx build --platform linux/arm64,linux/amd64 \
+		-t ${DB_CONTAINER_NAME}:${CONTAINER_VERSION} \
+		-f ./database/Dockerfile \
+		./database \
+		--push
+	docker buildx rm multi-db
 
 build_linux:
-	CGO_ENABLED=0 GOOS=linux go build -o ./bin/product-api
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./bin/amd64/product-api
 
-build_docker: build_linux
-	docker build -t ${CONTAINER_NAME}:${CONTAINER_VERSION} .
+build_arm64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/arm64/product-api
 
-push_docker: build_docker
-	docker push ${CONTAINER_NAME}:${CONTAINER_VERSION}
+build_docker: build_linux build_arm64
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	docker buildx create --name multi || true
+	docker buildx use multi
+	docker buildx inspect --bootstrap
+	docker buildx build --platform linux/arm64,linux/amd64 \
+		-t ${CONTAINER_NAME}:${CONTAINER_VERSION} \
+		-f ./Dockerfile \
+		./bin \
+		--push
+	docker buildx rm multi

--- a/blueprint/stack.hcl
+++ b/blueprint/stack.hcl
@@ -8,7 +8,7 @@ container "db" {
     }
 
     image {
-        name = "hashicorpdemoapp/product-api-db:v0.0.16"
+        name = "hashicorpdemoapp/product-api-db:v0.0.15"
     }
 
     env {
@@ -39,7 +39,7 @@ container "api" {
     }
 
     image {
-        name = "hashicorpdemoapp/product-api:v0.0.16"
+        name = "hashicorpdemoapp/product-api:v0.0.15"
     }
 
     volume {

--- a/blueprint/stack.hcl
+++ b/blueprint/stack.hcl
@@ -8,7 +8,7 @@ container "db" {
     }
 
     image {
-        name = "hashicorpdemoapp/product-api-db:v0.0.15"
+        name = "hashicorpdemoapp/product-api-db:v0.0.16"
     }
 
     env {
@@ -20,12 +20,12 @@ container "db" {
         key = "POSTGRES_USER"
         value = "postgres"
     }
-    
+
     env {
         key = "POSTGRES_PASSWORD"
         value = "password"
     }
-    
+
     port {
         local = 5432
         remote = 5432
@@ -39,7 +39,7 @@ container "api" {
     }
 
     image {
-        name = "hashicorpdemoapp/product-api:v0.0.15"
+        name = "hashicorpdemoapp/product-api:v0.0.16"
     }
 
     volume {
@@ -51,7 +51,7 @@ container "api" {
         key = "CONFIG_FILE"
         value = "/config/config.json"
     }
-    
+
     port {
         local = 9090
         remote = 9090

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,3 +1,16 @@
-FROM hashicorpdemoapp/postgres:11.6 
+FROM postgres:11.6 as base
+
+FROM base AS image-amd64
+
 COPY products.sql /docker-entrypoint-initdb.d/
 RUN chmod a+r /docker-entrypoint-initdb.d/*
+
+FROM base AS image-arm64
+
+COPY products.sql /docker-entrypoint-initdb.d/
+RUN chmod a+r /docker-entrypoint-initdb.d/*
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"

--- a/database/products.sql
+++ b/database/products.sql
@@ -2,56 +2,56 @@ set time zone 'UTC';
 create extension pgcrypto;
 
 CREATE TABLE coffees (
-    id serial PRIMARY KEY, 
+    id serial PRIMARY KEY,
     name VARCHAR (255) NOT NULL UNIQUE,
     teaser VARCHAR(255) NULL,
     description TEXT NULL,
     price INT NOT NULL,
     image TEXT,
-    created_at TIMESTAMP NOT NULL, 
+    created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL,
     deleted_at TIMESTAMP
 );
 CREATE TABLE ingredients (
-    id serial PRIMARY KEY, 
-    name VARCHAR (255) NOT NULL,  
-    created_at TIMESTAMP NOT NULL, 
-    updated_at TIMESTAMP NOT NULL, 
+    id serial PRIMARY KEY,
+    name VARCHAR (255) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     deleted_at TIMESTAMP
 );
 CREATE TABLE coffee_ingredients (
-    id serial PRIMARY KEY, 
+    id serial PRIMARY KEY,
     coffee_id int references coffees(id),
     ingredient_id int references ingredients(id),
-    quantity int NOT NULL, 
-    unit VARCHAR (50) NOT NULL, 
-    created_at TIMESTAMP NOT NULL, 
-    updated_at TIMESTAMP NOT NULL, 
+    quantity int NOT NULL,
+    unit VARCHAR (50) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     deleted_at TIMESTAMP,
     CONSTRAINT unique_coffee_ingredient UNIQUE (coffee_id,ingredient_id)
 );
 CREATE TABLE users (
-    id serial PRIMARY KEY, 
+    id serial PRIMARY KEY,
     username VARCHAR (255) NOT NULL UNIQUE,
     password TEXT NOT NULL,
-    created_at TIMESTAMP NOT NULL, 
-    updated_at TIMESTAMP NOT NULL, 
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     deleted_at TIMESTAMP
 );
 CREATE TABLE orders (
-    id serial PRIMARY KEY, 
-    user_id int references users(id), 
-    created_at TIMESTAMP NOT NULL, 
-    updated_at TIMESTAMP NOT NULL, 
+    id serial PRIMARY KEY,
+    user_id int references users(id),
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     deleted_at TIMESTAMP
 );
 CREATE TABLE order_items (
-    id serial PRIMARY KEY, 
-    order_id int references orders(id), 
-    coffee_id int references coffees(id), 
-    quantity int NOT NULL, 
-    created_at TIMESTAMP NOT NULL, 
-    updated_at TIMESTAMP NOT NULL, 
+    id serial PRIMARY KEY,
+    order_id int references orders(id),
+    coffee_id int references coffees(id),
+    quantity int NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
     deleted_at TIMESTAMP
 );
 

--- a/open_api.yaml
+++ b/open_api.yaml
@@ -13,29 +13,29 @@ paths:
           description: A JSON array of coffee
           content:
             application/json:
-              schema: 
+              schema:
                 type: array
-                items: 
+                items:
                   type: object
                   properties:
-                    id: 
+                    id:
                       type: integer
                       format: int64
                       example: 1
-                    name: 
+                    name:
                       type: string
                       example: "Latte"
-                    price: 
+                    price:
                       type: float
                       format: float64
                       example: 2.34
-                    created_at: 
+                    created_at:
                       type: datetime
                       example: 2020-01-10T00:00:00Z
-                    updated_at: 
+                    updated_at:
                       type: datetime
                       example: 2020-01-10T00:00:00Z
-                    deleted_at: 
+                    deleted_at:
                       type: datetime
                       example: 2020-01-10T00:00:00Z
                     ingredients:
@@ -51,27 +51,27 @@ paths:
           description: A JSON array of ingredients
           content:
             application/json:
-              schema: 
+              schema:
                 type: array
-                items: 
+                items:
                   type: object
                   properties:
-                    id: 
+                    id:
                       type: integer
                       format: int64
                       example: 1
-                    name: 
+                    name:
                       type: string
                       example: "Milk"
-                    quantity: 
+                    quantity:
                       type: string
                       example: 500ml
-                    created_at: 
+                    created_at:
                       type: datetime
                       example: 2020-01-10T00:00:00Z
-                    updated_at: 
+                    updated_at:
                       type: datetime
                       example: 2020-01-10T00:00:00Z
-                    deleted_at: 
+                    deleted_at:
                       type: datetime
                       example: 2020-01-10T00:00:00Z


### PR DESCRIPTION
This configures CircleCI with Docker buildx to create containers for `amd64` and `arm64` (required for running containers on M1 Mac).

Closes #18. 