### PR TITLE
Add token revocation to user authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CONTAINER_NAME=hashicorpdemoapp/product-api
 DB_CONTAINER_NAME=hashicorpdemoapp/product-api-db
-CONTAINER_VERSION=v0.0.16
+CONTAINER_VERSION=v0.0.17
 
 test_functional:
 	shipyard run ./blueprint

--- a/blueprint/stack.hcl
+++ b/blueprint/stack.hcl
@@ -8,7 +8,7 @@ container "db" {
     }
 
     image {
-        name = "hashicorpdemoapp/product-api-db:v0.0.15"
+        name = "hashicorpdemoapp/product-api-db:v0.0.16"
     }
 
     env {
@@ -39,7 +39,7 @@ container "api" {
     }
 
     image {
-        name = "hashicorpdemoapp/product-api:v0.0.15"
+        name = "hashicorpdemoapp/product-api:v0.0.16"
     }
 
     volume {

--- a/data/connection.go
+++ b/data/connection.go
@@ -13,6 +13,9 @@ type Connection interface {
 	GetIngredientsForCoffee(int) (model.Ingredients, error)
 	CreateUser(string, string) (model.User, error)
 	AuthUser(string, string) (model.User, error)
+	CreateToken(int) (model.Token, error)
+	GetToken(int, int) (model.Token, error)
+	DeleteToken(int, int) error
 	GetOrders(int, *int) (model.Orders, error)
 	CreateOrder(int, []model.OrderItems) (model.Order, error)
 	UpdateOrder(int, int, []model.OrderItems) (model.Order, error)
@@ -125,6 +128,70 @@ func (c *PostgresSQL) AuthUser(username string, password string) (model.User, er
 	}
 
 	return us[0], nil
+}
+
+// CreateToken creates a new token
+func (c *PostgresSQL) CreateToken(userID int) (model.Token, error) {
+	token := model.Token{}
+
+	rows, err := c.db.NamedQuery(
+		`INSERT INTO tokens (user_id, created_at) 
+		VALUES(:user_id, now(), now()) 
+		RETURNING id;`, map[string]interface{}{
+			"user_id": userID,
+		})
+	if err != nil {
+		return token, err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		err := rows.StructScan(&token)
+		if err != nil {
+			return token, err
+		}
+	}
+
+	return token, nil
+}
+
+// GetToken checks whether token exists
+func (c *PostgresSQL) GetToken(tokenID int, userID int) (model.Token, error) {
+	token := []model.Token{}
+
+	err := c.db.Select(&token,
+		`SELECT id, user_id FROM tokens 
+		WHERE id = $1 AND user_id = $2;`,
+		tokenID, userID,
+	)
+	if err != nil {
+		return token[0], err
+	}
+
+	return token[0], nil
+}
+
+// DeleteToken deletes an existing token in the database
+func (c *PostgresSQL) DeleteToken(tokenID int, userID int) error {
+	tx := c.db.MustBegin()
+
+	_, err := tx.NamedExec(
+		`UPDATE tokens SET deleted_at = now()
+		WHERE id = :token_id AND user_id = :user_id AND deleted_at IS NULL`, map[string]interface{}{
+			"token_id": tokenID,
+			"user_id":  userID,
+		})
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // GetOrders returns orders from the database

--- a/data/mockcon.go
+++ b/data/mockcon.go
@@ -58,6 +58,39 @@ func (c *MockConnection) AuthUser(username string, password string) (model.User,
 	return model.User{}, args.Error(1)
 }
 
+// CreateToken -
+func (c *MockConnection) CreateToken(userID int) (model.Token, error) {
+	args := c.Called()
+
+	if m, ok := args.Get(0).(model.Token); ok {
+		return m, args.Error(1)
+	}
+
+	return model.Token{}, args.Error(1)
+}
+
+// GetToken -
+func (c *MockConnection) GetToken(tokenID int, userID int) (model.Token, error) {
+	args := c.Called()
+
+	if m, ok := args.Get(0).(model.Token); ok {
+		return m, args.Error(1)
+	}
+
+	return model.Token{}, args.Error(1)
+}
+
+// DeleteToken -
+func (c *MockConnection) DeleteToken(tokenID int, userID int) error {
+	args := c.Called()
+
+	if err, ok := args.Get(0).(error); ok {
+		return err
+	}
+
+	return nil
+}
+
 // GetOrders -
 func (c *MockConnection) GetOrders(userID int, orderID *int) (model.Orders, error) {
 	args := c.Called()

--- a/data/model/order_test.go
+++ b/data/model/order_test.go
@@ -28,11 +28,11 @@ func TestOrdersSerializesToJSON(t *testing.T) {
 		Order{
 			ID: 1,
 			Items: []OrderItems{
-				OrderItems{
+				{
 					Coffee:   Coffee{ID: 0},
 					Quantity: 1,
 				},
-				OrderItems{
+				{
 					Coffee:   Coffee{ID: 1},
 					Quantity: 2,
 				},

--- a/data/model/token.go
+++ b/data/model/token.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// Token defines a JWT in the database
+type Token struct {
+	ID        int    `db:"id" json:"id"`
+	UserID    int    `db:"user_id" json:"user_id"`
+	CreatedAt string `db:"created_at" json:"-"`
+	DeletedAt string `db:"deleted_at" json:"-"`
+}
+
+// FromJSON serializes data from json
+func (t *Token) FromJSON(data io.Reader) error {
+	de := json.NewDecoder(data)
+	return de.Decode(t)
+}
+
+// ToJSON converts the collection to json
+func (t *Token) ToJSON() ([]byte, error) {
+	return json.Marshal(t)
+}

--- a/data/model/token_test.go
+++ b/data/model/token_test.go
@@ -1,0 +1,40 @@
+package model
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenDeserializeFromJSON(t *testing.T) {
+	to := Token{}
+
+	err := to.FromJSON(bytes.NewReader([]byte(tokenData)))
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, to.ID)
+	assert.Equal(t, 5, to.UserID)
+}
+
+func TestTokenSerializesToJSON(t *testing.T) {
+	to := Token{ID: 1, UserID: 5}
+
+	d, err := to.ToJSON()
+	assert.NoError(t, err)
+
+	tod := make(map[string]interface{}, 0)
+	err = json.Unmarshal(d, &tod)
+	assert.NoError(t, err)
+
+	assert.Equal(t, float64(1), tod["id"])
+	assert.Equal(t, float64(5), tod["user_id"])
+}
+
+var tokenData = `
+{
+	"id": 1,
+	"user_id": 5
+}
+`

--- a/database/products.sql
+++ b/database/products.sql
@@ -38,6 +38,12 @@ CREATE TABLE users (
     updated_at TIMESTAMP NOT NULL,
     deleted_at TIMESTAMP
 );
+CREATE TABLE tokens (
+    id serial PRIMARY KEY,
+    user_id int references users(id),
+    created_at TIMESTAMP NOT NULL,
+    deleted_at TIMESTAMP
+);
 CREATE TABLE orders (
     id serial PRIMARY KEY,
     user_id int references users(id),

--- a/docker_compose/docker-compose.yml
+++ b/docker_compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   api:
-    image: "hashicorpdemoapp/product-api:v0.0.12"
+    image: "hashicorpdemoapp/product-api:v0.0.16"
     ports:
       - "19090:9090"
     volumes:
@@ -11,7 +11,7 @@ services:
     depends_on:
       - db
   db:
-    image: "hashicorpdemoapp/product-api-db:v0.0.12"
+    image: "hashicorpdemoapp/product-api-db:v0.0.16"
     ports:
       - "15432:5432"
     environment:

--- a/functional_tests/features/user.feature
+++ b/functional_tests/features/user.feature
@@ -19,3 +19,8 @@ Feature: Basic User Functionality
       """
     Then an AuthResponse should be returned
     And the response status should be "OK"
+
+  Scenario: Sign out user
+    Given the server is running
+    When I make a "POST" request to "/signout" where the request header is "Authorization" with the value "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjYxODc2NjYsInRva2VuX2lkIjoyLCJ1c2VyX2lkIjoxLCJ1c2VybmFtZSI6IlVzZXIxIn0.xprj5axiIs2NyrIVHJt_1G4eG3cDkHC1p84vhOsx4JI":
+    Then the response status should be "OK"

--- a/functional_tests/helper_test.go
+++ b/functional_tests/helper_test.go
@@ -31,18 +31,22 @@ func (api *apiFeature) initHandlers() {
 	// User
 	mc.On("CreateUser").Return(model.User{ID: 1, Username: "User1"}, nil)
 	mc.On("AuthUser").Return(model.User{ID: 1, Username: "User1"}, nil)
+	// Token
+	mc.On("CreateToken").Return(model.Token{ID: 1, UserID: 1}, nil)
+	mc.On("GetToken").Return(model.Token{ID: 1, UserID: 1}, nil)
+	mc.On("DeleteToken").Return(nil)
 	// Order
 	testOrder := model.Order{
 		ID: 1,
 		Items: []model.OrderItems{
-			model.OrderItems{
+			{
 				Coffee: model.Coffee{
 					ID:   1,
 					Name: "Latte",
 				},
 				Quantity: 1,
 			},
-			model.OrderItems{
+			{
 				Coffee: model.Coffee{
 					ID:   2,
 					Name: "Mocha",
@@ -109,6 +113,9 @@ func (api *apiFeature) initRouter(method, endpoint string, userID *string) error
 	if strings.Contains(endpoint, "/signin") {
 		api.hu.SignIn(api.rw, api.r)
 	}
+	if strings.Contains(endpoint, "/signout") {
+		api.hu.SignOut(api.rw, api.r)
+	}
 	return nil
 }
 
@@ -156,6 +163,24 @@ func (api *apiFeature) iMakeARequestToWithTheFollowingRequestBody(method, endpoi
 
 	rb := strings.NewReader(body.Content)
 	api.r.Body = ioutil.NopCloser(rb)
+
+	err := api.initRouter(method, endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (api *apiFeature) iMakeARequestToWhereTheRequestHeaderIsWithTheValue(method, endpoint, header, value string) error {
+	api.rw = httptest.NewRecorder()
+	api.r = httptest.NewRequest(method, endpoint, nil)
+
+	api.r.Header = http.Header{
+		header: {
+			value,
+		},
+	}
 
 	err := api.initRouter(method, endpoint, nil)
 	if err != nil {

--- a/functional_tests/main_test.go
+++ b/functional_tests/main_test.go
@@ -78,6 +78,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^I make a "([^"]*)" request to "([^"]*)" where my userID is "([^"]*)" with the following request body:$`, api.iMakeARequestToWhereMyUserIDIsWithTheFollowingRequestBody)
 	s.Step(`^I make a "([^"]*)" request to "([^"]*)" where "([^"]*)" is "([^"]*)" and my userID is "([^"]*)"$`, api.iMakeARequestToWhereIsAndMyUserIDIs)
 	s.Step(`^I make a "([^"]*)" request to "([^"]*)" where "([^"]*)" is "([^"]*)" and my userID is "([^"]*)", with the following request body:$`, api.iMakeARequestToWhereIsAndMyUserIDIsWithTheFollowingRequestBody)
+	s.Step(`^I make a "([^"]*)" request to "([^"]*)" where the request header is "([^"]*)" with the value "([^"]*)":$`, api.iMakeARequestToWhereTheRequestHeaderIsWithTheValue)
 
 	s.Step(`^a list of products should be returned$`, api.aListOfProductsShouldBeReturned)
 	s.Step(`^a list of the product\'s ingredients should be returned$`, api.thatProductsIngredientsShouldBeReturned)

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/hashicorp-demoapp/product-api-go/data"
+	"github.com/hashicorp/go-hclog"
+)
+
+// Middleware -
+type AuthMiddleware struct {
+	con data.Connection
+	log hclog.Logger
+}
+
+// NewMiddleware -
+func NewAuthMiddleware(con data.Connection, l hclog.Logger) *AuthMiddleware {
+	return &AuthMiddleware{con, l}
+}
+
+// ExtractJWT retrieves the token and user ID from the JWT
+func ExtractJWT(authToken string) (int, int, error) {
+	token, err := jwt.Parse(authToken, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, nil
+		}
+		return []byte(jwtSecret), nil
+	})
+
+	if err != nil {
+		return -1, -1, err
+	}
+
+	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+		tokenID := int(claims["token_id"].(float64))
+		userID := int(claims["user_id"].(float64))
+		return tokenID, userID, nil
+	}
+	return -1, -1, nil
+}
+
+func (c *AuthMiddleware) VerifyJWT(authToken string) (int, error) {
+	tokenID, userID, err := ExtractJWT(authToken)
+	if err != nil {
+		return userID, err
+	}
+	if _, err := c.con.GetToken(tokenID, userID); err != nil {
+		return userID, err
+	}
+	return userID, nil
+}
+
+// IsAuthorized
+func (c *AuthMiddleware) IsAuthorized(next func(userID int, w http.ResponseWriter, r *http.Request)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authToken := r.Header.Get("Authorization")
+		userID, err := c.VerifyJWT(authToken)
+		if err == nil {
+			next(userID, w, r)
+			return
+		}
+		c.log.Error("Unauthorized", "error", err)
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	})
+}

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -152,4 +152,6 @@ func (c *User) SignOut(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "Unable to sign out user", http.StatusInternalServerError)
 		return
 	}
+
+	fmt.Fprintf(rw, "%s", "Signed out user")
 }

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -67,7 +67,7 @@ func (c *User) SignUp(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tokenString, err := generateJWTToken(u.ID, u.Username)
+	tokenString, err := c.generateJWTToken(u.ID, u.Username)
 	if err != nil {
 		c.log.Error("Unable to generate JWT token", "error", err)
 		http.Error(rw, "Unable to generate JWT token", http.StatusInternalServerError)
@@ -101,7 +101,7 @@ func (c *User) SignIn(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tokenString, err := generateJWTToken(u.ID, u.Username)
+	tokenString, err := c.generateJWTToken(u.ID, u.Username)
 	if err != nil {
 		c.log.Error("Unable to generate JWT token", "error", err)
 		http.Error(rw, "Unable to generate JWT token", http.StatusInternalServerError)
@@ -115,12 +115,41 @@ func (c *User) SignIn(rw http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func generateJWTToken(id int, username string) (string, error) {
+func (c *User) generateJWTToken(userID int, username string) (string, error) {
+	t, err := c.con.CreateToken(userID)
+	if err != nil {
+		return "", err
+	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user_id":  id,
+		"token_id": t.ID,
+		"user_id":  userID,
 		"username": username,
 		"exp":      time.Now().Add(time.Hour * 24).Unix(),
 	})
 
 	return token.SignedString([]byte(jwtSecret))
+}
+
+func (c *User) invalidateJWTToken(authToken string) error {
+	tokenID, userID, err := ExtractJWT(authToken)
+	if err != nil {
+		return err
+	}
+	if err = c.con.DeleteToken(tokenID, userID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SignOut signs out a user and invalidates a JWT token
+func (c *User) SignOut(rw http.ResponseWriter, r *http.Request) {
+	c.log.Info("Handle User | signout")
+
+	authToken := r.Header.Get("Authorization")
+
+	if err := c.invalidateJWTToken(authToken); err != nil {
+		c.log.Error("Unable to sign out user", "error", err)
+		http.Error(rw, "Unable to sign out user", http.StatusInternalServerError)
+		return
+	}
 }

--- a/handlers/user_test.go
+++ b/handlers/user_test.go
@@ -80,6 +80,7 @@ func TestSignOutUser(t *testing.T) {
 	c, rw := setupUserHandler(t)
 
 	token, err := c.generateJWTToken(1, "User1")
+	fmt.Println(token)
 	assert.NoError(t, err)
 
 	r := httptest.NewRequest("POST", "/signout", nil)

--- a/handlers/user_test.go
+++ b/handlers/user_test.go
@@ -21,6 +21,8 @@ func setupUserHandler(t *testing.T) (*User, *httptest.ResponseRecorder) {
 
 	c.On("CreateUser").Return(model.User{ID: 1, Username: "User1"}, nil)
 	c.On("AuthUser").Return(model.User{ID: 1, Username: "User1"}, nil)
+	c.On("CreateToken").Return(model.Token{ID: 2, UserID: 1}, nil)
+	c.On("DeleteToken").Return(nil)
 
 	l := hclog.Default()
 
@@ -32,11 +34,14 @@ func setupFailedUserHandler(t *testing.T) (*User, *httptest.ResponseRecorder) {
 
 	c.On("CreateUser").Return(nil, errors.New("Unable to create new user"))
 	c.On("AuthUser").Return(nil, errors.New("Unable to login with credentials"))
+	c.On("CreateToken").Return(nil, errors.New("Unable to create new token"))
+	c.On("DeleteToken").Return(nil, errors.New("Unable to delete token"))
 
 	l := hclog.Default()
 
 	return &User{c, l}, httptest.NewRecorder()
 }
+
 func TestCreateNewUser(t *testing.T) {
 	c, rw := setupUserHandler(t)
 
@@ -71,7 +76,41 @@ func TestAuthNewUser(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSignOutUser(t *testing.T) {
+	c, rw := setupUserHandler(t)
+
+	token, err := c.generateJWTToken(1, "User1")
+	assert.NoError(t, err)
+
+	r := httptest.NewRequest("POST", "/signout", nil)
+	r.Header.Add("Authorization", token)
+
+	c.SignOut(rw, r)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+}
+
 func TestUnableToCreateNewUser(t *testing.T) {
+	c, rw := setupFailedUserHandler(t)
+
+	r := httptest.NewRequest("POST", "/signup", nil)
+
+	username := "User1"
+
+	rb := strings.NewReader(fmt.Sprintf(`{"username": "%+s", "password": "testPassword"}`, username))
+	r.Body = ioutil.NopCloser(rb)
+
+	c.SignUp(rw, r)
+
+	assert.Equal(t, http.StatusInternalServerError, rw.Code)
+
+	bd := model.User{}
+	err := json.Unmarshal(rw.Body.Bytes(), &bd)
+	assert.Error(t, err)
+	assert.Equal(t, fmt.Sprintf("Unable to sign up user: %+s\n", username), string(rw.Body.Bytes()))
+}
+
+func TestUnableToCreateNewToken(t *testing.T) {
 	c, rw := setupFailedUserHandler(t)
 
 	r := httptest.NewRequest("POST", "/signup", nil)
@@ -107,4 +146,16 @@ func TestUnableToAuthNewUser(t *testing.T) {
 	err := json.Unmarshal(rw.Body.Bytes(), &bd)
 	assert.Error(t, err)
 	assert.Equal(t, "Invalid Credentials\n", string(rw.Body.Bytes()))
+}
+
+func TestUnableToSignOutUser(t *testing.T) {
+	c, rw := setupFailedUserHandler(t)
+
+	r := httptest.NewRequest("POST", "/signout", nil)
+	r.Header.Add("Authorization", "{}")
+
+	c.SignOut(rw, r)
+
+	assert.Equal(t, http.StatusInternalServerError, rw.Code)
+	assert.Equal(t, fmt.Sprintf("Unable to sign out user\n"), string(rw.Body.Bytes()))
 }

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/hashicorp-demoapp/go-hckit"
 	"github.com/nicholasjackson/env"
 
@@ -70,66 +69,36 @@ func main() {
 	r := mux.NewRouter()
 	r.Use(hckit.TracingMiddleware)
 
+	authMiddleware := handlers.NewAuthMiddleware(db, logger)
+
 	healthHandler := handlers.NewHealth(t, logger, db)
 	r.Handle("/health", healthHandler).Methods("GET")
 
 	coffeeHandler := handlers.NewCoffee(db, logger)
 	r.Handle("/coffees", coffeeHandler).Methods("GET")
-	r.Handle("/coffees", isAuthorizedMiddleware(coffeeHandler.CreateCoffee)).Methods("POST")
+	r.Handle("/coffees", authMiddleware.IsAuthorized(coffeeHandler.CreateCoffee)).Methods("POST")
 
 	ingredientsHandler := handlers.NewIngredients(db, logger)
 	r.Handle("/coffees/{id:[0-9]+}/ingredients", ingredientsHandler).Methods("GET")
-	r.Handle("/coffees/{id:[0-9]+}/ingredients", isAuthorizedMiddleware(ingredientsHandler.CreateCoffeeIngredient)).Methods("POST")
+	r.Handle("/coffees/{id:[0-9]+}/ingredients", authMiddleware.IsAuthorized(ingredientsHandler.CreateCoffeeIngredient)).Methods("POST")
 
 	userHandler := handlers.NewUser(db, logger)
 	r.HandleFunc("/signup", userHandler.SignUp).Methods("POST")
 	r.HandleFunc("/signin", userHandler.SignIn).Methods("POST")
+	r.HandleFunc("/signout", userHandler.SignOut).Methods("POST")
 
 	orderHandler := handlers.NewOrder(db, logger)
-	r.Handle("/orders", isAuthorizedMiddleware(orderHandler.GetUserOrders)).Methods("GET")
-	r.Handle("/orders", isAuthorizedMiddleware(orderHandler.CreateOrder)).Methods("POST")
-	r.Handle("/orders/{id:[0-9]+}", isAuthorizedMiddleware(orderHandler.GetUserOrder)).Methods("GET")
-	r.Handle("/orders/{id:[0-9]+}", isAuthorizedMiddleware(orderHandler.UpdateOrder)).Methods("PUT")
-	r.Handle("/orders/{id:[0-9]+}", isAuthorizedMiddleware(orderHandler.DeleteOrder)).Methods("DELETE")
+	r.Handle("/orders", authMiddleware.IsAuthorized(orderHandler.GetUserOrders)).Methods("GET")
+	r.Handle("/orders", authMiddleware.IsAuthorized(orderHandler.CreateOrder)).Methods("POST")
+	r.Handle("/orders/{id:[0-9]+}", authMiddleware.IsAuthorized(orderHandler.GetUserOrder)).Methods("GET")
+	r.Handle("/orders/{id:[0-9]+}", authMiddleware.IsAuthorized(orderHandler.UpdateOrder)).Methods("PUT")
+	r.Handle("/orders/{id:[0-9]+}", authMiddleware.IsAuthorized(orderHandler.DeleteOrder)).Methods("DELETE")
 
 	logger.Info("Starting service", "bind", conf.BindAddress, "metrics", conf.MetricsAddress)
 	err = http.ListenAndServe(conf.BindAddress, r)
 	if err != nil {
 		logger.Error("Unable to start server", "bind", conf.BindAddress, "error", err)
 	}
-}
-
-// isAuthorizedMiddleware
-func isAuthorizedMiddleware(next func(userID int, w http.ResponseWriter, r *http.Request)) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		authToken := r.Header.Get("Authorization")
-
-		token, err := jwt.Parse(authToken, func(token *jwt.Token) (interface{}, error) {
-			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-				logger.Error("Unable to parse JWT token", "path", r.URL.Path)
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return nil, nil
-			}
-			return []byte(jwtSecret), nil
-		})
-
-		if err != nil {
-			logger.Error("Unauthorized", "error", err)
-			http.Error(w, err.Error(), http.StatusUnauthorized)
-			return
-		}
-
-		// if token is valid
-		if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
-			userID := int(claims["user_id"].(float64))
-			next(userID, w, r)
-			return
-		}
-
-		logger.Error("Invalid Token", "error", err)
-		http.Error(w, err.Error(), http.StatusUnauthorized)
-		return
-	})
 }
 
 // retryDBUntilReady keeps retrying the database connection


### PR DESCRIPTION
Closes #9.

- Adds a new `/signout` API endpoint
- Adds new table to database to track deleted tokens.