### PR TITLE
Use env vars to configure app alternatively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CONTAINER_NAME=hashicorpdemoapp/product-api
 DB_CONTAINER_NAME=hashicorpdemoapp/product-api-db
-CONTAINER_VERSION=v0.0.17
+CONTAINER_VERSION=v0.0.18
 
 test_functional:
 	shipyard run ./blueprint

--- a/main.go
+++ b/main.go
@@ -27,6 +27,9 @@ var conf *Config
 var logger hclog.Logger
 
 var configFile = env.String("CONFIG_FILE", false, "./conf.json", "Path to JSON encoded config file")
+var dbConnection = env.String("DB_CONNECTION", false, "host=localhost port=5432 user=postgres password=password dbname=products sslmode=disable", "db connection string")
+var bindAddress = env.String("BIND_ADDRESS", false, "0.0.0.0:9090", "Bind address")
+var metricsAddress = env.String("METRICS_ADDRESS", false, "0.0.0.0:9091", "Metrics address")
 
 const jwtSecret = "test"
 
@@ -46,7 +49,11 @@ func main() {
 	}
 	defer closer.Close()
 
-	conf = &Config{}
+	conf = &Config{
+		DBConnection: *dbConnection,
+		BindAddress: *bindAddress,
+		MetricsAddress: *metricsAddress,
+	}
 
 	// load the config
 	c, err := config.New(*configFile, conf, configUpdated)

--- a/main.go
+++ b/main.go
@@ -55,13 +55,15 @@ func main() {
 		MetricsAddress: *metricsAddress,
 	}
 
-	// load the config
-	c, err := config.New(*configFile, conf, configUpdated)
-	if err != nil {
-		logger.Error("Unable to load config file", "error", err)
-		os.Exit(1)
+	// load the config, unless provided by env
+	if conf.DBConnection == "" || conf.BindAddress == "" {
+		c, err := config.New(*configFile, conf, configUpdated)
+		if err != nil {
+			logger.Error("Unable to load config file", "error", err)
+			os.Exit(1)
+		}
+		defer c.Close()
 	}
-	defer c.Close()
 
 	// configure the telemetry
 	t := telemetry.New(conf.MetricsAddress)

--- a/main.go
+++ b/main.go
@@ -27,9 +27,9 @@ var conf *Config
 var logger hclog.Logger
 
 var configFile = env.String("CONFIG_FILE", false, "./conf.json", "Path to JSON encoded config file")
-var dbConnection = env.String("DB_CONNECTION", false, "host=localhost port=5432 user=postgres password=password dbname=products sslmode=disable", "db connection string")
-var bindAddress = env.String("BIND_ADDRESS", false, "0.0.0.0:9090", "Bind address")
-var metricsAddress = env.String("METRICS_ADDRESS", false, "0.0.0.0:9091", "Metrics address")
+var dbConnection = env.String("DB_CONNECTION", false, "", "db connection string")
+var bindAddress = env.String("BIND_ADDRESS", false, "", "Bind address")
+var metricsAddress = env.String("METRICS_ADDRESS", false, "", "Metrics address")
 
 const jwtSecret = "test"
 


### PR DESCRIPTION
This PR enables configuration via environment variables. Both `DB_CONNECTION`and `BIND_ADDRESS` have to be set, otherwise the code falls back to loading from file.