### PR TITLE
Support DB connection max retries parameter

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -1,5 +1,7 @@
 {
-  "db_connection": "host=localhost port=15432 user=postgres password=password dbname=products sslmode=disable",
+  "db_connection": "host=localhost port=15432 user=postgres password=password dbname=products sslmode=disable connect_timeout=10 ",
   "bind_address": "localhost:9090",
-  "metrics_address": "localhost:9102"
+  "metrics_address": "localhost:9102",
+  "max_retries": 60,
+  "backoff_exponential_base": 1
 }


### PR DESCRIPTION
This PR introduces the changes to handle the maximum number of database connection retries. This new parameters should be set in the configuration file read by the application (conf.json).

Also, on Windows OS, sometimes the connection attempt freezes and it does not respond again. product-api uses the [sqlx package](https://pkg.go.dev/github.com/jmoiron/sqlx) to create the DB connection. This occurs in the internal method “ping” of this package which by default waits indefinitely. To solve this issue, based/on [sqlx documentation](https://pkg.go.dev/github.com/lib/pq?utm_source=godoc#hdr-Connection_String_Parameters), we added the “connect_timeout” variable in the DB connection string (db_parameter) of the config.json file with 10 seconds as default value. This new variable allows to set the maximum time to wait for the connection. If product-api can’t connect to database, it continues to next retry.

- `maxRetries`: Max number of retries
- `backoffExponentialBase`: base number used to calculate the exponential back-off before attempting to connect again
- `connect_timeout`: Whole timeout for connection to the DB

