### PR TITLE
Upgrade postgres version and fix health checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CONTAINER_NAME=hashicorpdemoapp/product-api
 DB_CONTAINER_NAME=hashicorpdemoapp/product-api-db
-CONTAINER_VERSION=v0.0.22
+CONTAINER_VERSION=v0.0.23
 
 test_functional:
 	shipyard run ./blueprint

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:11.6 as base
+FROM postgres:16.4 as base
 
 FROM base AS image-amd64
 

--- a/docker_compose/docker-compose.yml
+++ b/docker_compose/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3.7'
 services:
   api:
-    image: "hashicorpdemoapp/product-api:v0.0.22"
+    image: "hashicorpdemoapp/product-api:v0.0.23"
     ports:
       - "19090:9090"
     volumes:
@@ -11,7 +10,7 @@ services:
     depends_on:
       - db
   db:
-    image: "hashicorpdemoapp/product-api-db:v0.0.22"
+    image: "hashicorpdemoapp/product-api-db:v0.0.23"
     ports:
       - "15432:5432"
     environment:

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -37,7 +37,7 @@ func (h *Health) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(rw, "error %s", err)
 	}
 
-	fmt.Fprintf(rw, "%s", "not ok")
+	fmt.Fprintf(rw, "%s", "ok")
 }
 
 // Liveness endpoint for health checks indicates server has started


### PR DESCRIPTION
Based on this [slack thread](https://hashicorp.slack.com/archives/CTWD5V24T/p1726763740243299) to fix a container vulnerability.

```
This is a container vulnerability, Image: hashicorpdemoapp/product-api-db:v0.0.21
Description: Upgrade package gnupg to version 2.2.41 or above.
```

This upgrades the container image for both the API and DB to `0.0.23`