### PR TITLE
fix: added missing db fields to insert statement

### DIFF
--- a/data/connection.go
+++ b/data/connection.go
@@ -427,11 +427,14 @@ func (c *PostgresSQL) CreateCoffee(coffee model.Coffee) (model.Coffee, error) {
 	m := model.Coffee{}
 
 	rows, err := c.db.NamedQuery(
-		`INSERT INTO coffees (name, teaser, description, price, image, created_at, updated_at) 
-		VALUES(:name, :teaser, :description, :price, :image, now(), now()) 
+		`INSERT INTO coffees (name, teaser, collection, origin, color, description, price, image, created_at, updated_at) 
+		VALUES(:name, :teaser, :collection,:origin, :color, :description, :price, :image, now(), now()) 
 		RETURNING id;`, map[string]interface{}{
 			"name":        coffee.Name,
 			"teaser":      coffee.Teaser,
+			"collection":  coffee.Collection,
+			"origin":      coffee.Origin,
+			"color":       coffee.Color,
 			"description": coffee.Description,
 			"price":       coffee.Price,
 			"image":       coffee.Image,
@@ -443,12 +446,13 @@ func (c *PostgresSQL) CreateCoffee(coffee model.Coffee) (model.Coffee, error) {
 
 	if rows.Next() {
 		err := rows.StructScan(&m)
+		coffee.ID = m.ID
 		if err != nil {
 			return m, err
 		}
 	}
 
-	return m, nil
+	return coffee, nil
 }
 
 // UpsertCoffeeIngredient upserts a new coffee ingredient


### PR DESCRIPTION
The db fields for collection, origin or color weren't set upon creating a new coffee.
Therefore a GET to the new coffee id an error was raised by the api because the db fields were NULL.

PR should close #31